### PR TITLE
Clarify connection exception's role and hierarchy

### DIFF
--- a/examples/connection-close-detection.php
+++ b/examples/connection-close-detection.php
@@ -1,0 +1,227 @@
+<?php declare(strict_types=1);
+
+include __DIR__ . '/../vendor/autoload.php';
+
+use Ripple\Socket;
+use Ripple\Stream\Exception\ConnectionStateException;
+use Ripple\Stream\Exception\StreamInternalException;
+use Ripple\Utils\Output;
+
+use function Co\go;
+use function Co\wait;
+use function Co\sleep;
+
+/**
+ * 连接关闭检测示例
+ * 
+ * 展示不同场景下如何检测和处理连接关闭：
+ * 1. 被动检测：onClose 回调
+ * 2. 主动检测：isAlive() 和 assertAlive()
+ * 3. 异常检测：在 I/O 操作中捕获异常
+ * 4. 半关闭检测：isHalfClosed()
+ */
+
+// 场景1：被动检测 - 使用 onClose 回调
+go(function () {
+    Output::info("=== 场景1: 被动检测 (onClose) ===");
+    
+    $server = Socket::server('tcp://127.0.0.1:9001');
+    $server->setBlocking(false);
+    
+    $server->onReadable(function () use ($server) {
+        $client = $server->accept();
+        $client->setBlocking(false);
+        
+        // 设置关闭回调
+        $client->onClose(function () {
+            Output::success("✓ onClose: 客户端连接已关闭");
+        });
+        
+        $client->onReadable(function () use ($client) {
+            try {
+                $data = $client->read(1024);
+                if ($data === '') {
+                    Output::info("收到空数据，客户端可能已关闭");
+                    $client->close(); // 这会触发 onClose
+                    return;
+                }
+                Output::info("收到数据: " . trim($data));
+            } catch (StreamInternalException $e) {
+                // 底层异常，让其穿透
+                throw $e;
+            }
+        });
+    });
+    
+    sleep(0.1);
+    
+    // 模拟客户端连接并关闭
+    $client = Socket::connect('tcp://127.0.0.1:9001');
+    $client->write("Hello Server");
+    sleep(0.1);
+    $client->close(); // 这会触发服务端的 onClose
+    
+    sleep(0.5);
+    $server->close();
+});
+
+// 场景2：主动检测 - 在业务逻辑中检查连接状态
+go(function () {
+    Output::info("=== 场景2: 主动检测 (isAlive/assertAlive) ===");
+    
+    $server = Socket::server('tcp://127.0.0.1:9002');
+    $server->setBlocking(false);
+    
+    $server->onReadable(function () use ($server) {
+        $client = $server->accept();
+        $client->setBlocking(false);
+        
+        // 模拟批量操作，需要在过程中检测连接状态
+        go(function () use ($client) {
+            for ($i = 0; $i < 10; $i++) {
+                sleep(0.1);
+                
+                // 主动检测连接状态
+                if (!$client->isAlive()) {
+                    Output::warning("✗ 检测到连接已关闭，停止批量操作");
+                    break;
+                }
+                
+                try {
+                    // 断言连接活跃
+                    $client->assertAlive();
+                    Output::info("✓ 批量操作 $i: 连接正常");
+                } catch (ConnectionStateException $e) {
+                    Output::warning("✗ 连接状态异常: {$e->getMessage()} (原因: {$e->reason})");
+                    
+                    if ($e->shouldReconnect()) {
+                        Output::info("需要重连");
+                    } else {
+                        Output::info("优雅关闭，无需重连");
+                    }
+                    break;
+                }
+            }
+        });
+        
+        // 3秒后关闭客户端，模拟连接中断
+        sleep(3);
+        $client->close();
+    });
+    
+    sleep(0.1);
+    
+    $client = Socket::connect('tcp://127.0.0.1:9002');
+    $client->write("Start batch operation");
+    
+    sleep(5);
+    $server->close();
+});
+
+// 场景3：半关闭检测
+go(function () {
+    Output::info("=== 场景3: 半关闭检测 ===");
+    
+    $server = Socket::server('tcp://127.0.0.1:9003');
+    $server->setBlocking(false);
+    
+    $server->onReadable(function () use ($server) {
+        $client = $server->accept();
+        $client->setBlocking(false);
+        
+        $client->onReadable(function () use ($client) {
+            try {
+                $data = $client->read(1024);
+                
+                if ($data === '') {
+                    // 检查是否为半关闭状态
+                    if ($client->isHalfClosed()) {
+                        Output::info("✓ 检测到半关闭状态：对端关闭写端，但读端仍开放");
+                        // 发送确认消息后关闭
+                        $client->write("ACK: 收到所有数据\n");
+                        $client->close();
+                    } else {
+                        Output::info("连接完全关闭");
+                        $client->close();
+                    }
+                    return;
+                }
+                
+                Output::info("收到数据: " . trim($data));
+                
+            } catch (StreamInternalException $e) {
+                // 底层异常穿透
+                throw $e;
+            }
+        });
+    });
+    
+    sleep(0.1);
+    
+    $client = Socket::connect('tcp://127.0.0.1:9003');
+    $client->write("Test half-close");
+    sleep(0.1);
+    
+    // 模拟半关闭：关闭写端但保持读端
+    stream_socket_shutdown($client->getStream(), STREAM_SHUT_WR);
+    
+    sleep(1);
+    $client->close();
+    $server->close();
+});
+
+// 场景4：连接池健康检查
+go(function () {
+    Output::info("=== 场景4: 连接池健康检查 ===");
+    
+    class SimpleConnectionPool {
+        private array $connections = [];
+        
+        public function addConnection(Socket $conn): void {
+            $this->connections[] = $conn;
+        }
+        
+        public function getHealthyConnection(): ?Socket {
+            foreach ($this->connections as $index => $conn) {
+                if ($conn->isAlive()) {
+                    Output::success("✓ 连接 $index 健康");
+                    return $conn;
+                }
+                
+                Output::warning("✗ 连接 $index 已死亡，从池中移除");
+                unset($this->connections[$index]);
+            }
+            
+            Output::warning("连接池中无可用连接");
+            return null;
+        }
+        
+        public function getConnectionCount(): int {
+            return count($this->connections);
+        }
+    }
+    
+    $pool = new SimpleConnectionPool();
+    
+    // 创建一些连接
+    for ($i = 0; $i < 3; $i++) {
+        try {
+            $conn = Socket::connect('tcp://127.0.0.1:80'); // 假设这个地址不存在
+            $pool->addConnection($conn);
+        } catch (StreamInternalException $e) {
+            Output::warning("连接 $i 创建失败");
+        }
+    }
+    
+    Output::info("连接池初始大小: " . $pool->getConnectionCount());
+    
+    // 健康检查
+    $healthyConn = $pool->getHealthyConnection();
+    if ($healthyConn) {
+        Output::success("找到健康连接");
+    } else {
+        Output::info("无健康连接可用");
+    }
+});
+
+wait();

--- a/examples/socket-client.php
+++ b/examples/socket-client.php
@@ -4,6 +4,7 @@ include __DIR__ . '/../vendor/autoload.php';
 
 use Ripple\Socket;
 use Ripple\Stream\Exception\ConnectionException;
+use Ripple\Stream\Exception\StreamInternalException;
 use Ripple\Utils\Output;
 
 use function Co\wait;
@@ -14,8 +15,13 @@ try {
     #  Enable SSL
     // $connection->enableSSL();
     $connection->setBlocking(false);
+} catch (StreamInternalException $e) {
+    // 连接建立失败 - 这是框架层异常，但在连接阶段可以捕获
+    Output::warning("Connection failed: " . $e->getMessage());
+    exit(1);
 } catch (ConnectionException $e) {
-    Output::warning($e->getMessage());
+    // 其他应用层连接异常
+    Output::warning("Connection error: " . $e->getMessage());
     exit(1);
 }
 

--- a/src/Channel/Channel.php
+++ b/src/Channel/Channel.php
@@ -18,6 +18,7 @@ use Ripple\File\Lock;
 use Ripple\Kernel;
 use Ripple\Stream;
 use Ripple\Stream\Exception\ConnectionException;
+use Ripple\Stream\Exception\StreamInternalException;
 use Ripple\Utils\Path;
 use Ripple\Utils\Serialization\Zx7e;
 use Throwable;
@@ -199,6 +200,10 @@ class Channel
                         $this->stream->close();
                         throw new ConnectionException('Failed to read frame header.');
                     }
+                } catch (StreamInternalException $e) {
+                    // 内部异常转换为应用层异常
+                    $this->readLock->unlock();
+                    throw new ConnectionException('Connection lost while reading frame header.', 0, $e);
                 } catch (ConnectionException) {
                     $this->readLock->unlock();
                 }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -18,6 +18,7 @@ use Ripple\Coroutine\Context;
 use Ripple\Coroutine\Coroutine;
 use Ripple\Stream\Exception\ConnectionCloseException;
 use Ripple\Stream\Exception\ConnectionException;
+use Ripple\Stream\Exception\StreamInternalException;
 use Ripple\Stream\Exception\ConnectionTimeoutException;
 use Ripple\Stream\Stream as StreamBase;
 use Ripple\Utils\Format;
@@ -366,7 +367,7 @@ class Stream extends StreamBase
             return strlen($string);
         } catch (Throwable) {
             $this->close();
-            throw new ConnectionException('Unable to write to stream', ConnectionException::CONNECTION_WRITE_FAIL);
+            throw new StreamInternalException('Unable to write to stream', StreamInternalException::CONNECTION_WRITE_FAIL);
         }
     }
 
@@ -420,7 +421,7 @@ class Stream extends StreamBase
         foreach ($waiters as $waiter) {
             \Ripple\Coroutine::throw(
                 $waiter,
-                new ConnectionException('Unable to write to stream', ConnectionException::CONNECTION_WRITE_FAIL)
+                new StreamInternalException('Unable to write to stream', StreamInternalException::CONNECTION_WRITE_FAIL)
             );
         }
     }

--- a/src/Stream/Exception/ConnectionHandshakeException.php
+++ b/src/Stream/Exception/ConnectionHandshakeException.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © 2024 cclilshy
+ * Email: jingnigg@gmail.com
+ *
+ * This software is licensed under the MIT License.
+ * For full license details, please visit: https://opensource.org/licenses/MIT
+ *
+ * By using this software, you agree to the terms of the license.
+ * Contributions, suggestions, and feedback are always welcome!
+ */
+
+namespace Ripple\Stream\Exception;
+
+use Psr\Http\Message\StreamInterface;
+use Throwable;
+
+/**
+ * 连接握手异常
+ * 
+ * 用于表示连接握手过程中的错误，如 SSL/TLS 握手失败等。
+ * 这是应用层异常，用户可以捕获并处理（如重试、降级等）。
+ */
+class ConnectionHandshakeException extends ConnectionException
+{
+    public function __construct(
+        string          $message = "",
+        Throwable       $previous = null,
+        StreamInterface $stream = null,
+    ) {
+        parent::__construct(
+            $message,
+            ConnectionException::CONNECTION_HANDSHAKE_FAIL,
+            $previous,
+            $stream,
+        );
+    }
+}

--- a/src/Stream/Exception/ConnectionStateException.php
+++ b/src/Stream/Exception/ConnectionStateException.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © 2024 cclilshy
+ * Email: jingnigg@gmail.com
+ *
+ * This software is licensed under the MIT License.
+ * For full license details, please visit: https://opensource.org/licenses/MIT
+ *
+ * By using this software, you agree to the terms of the license.
+ * Contributions, suggestions, and feedback are always welcome!
+ */
+
+namespace Ripple\Stream\Exception;
+
+use Psr\Http\Message\StreamInterface;
+use Throwable;
+
+/**
+ * 连接状态异常
+ * 
+ * 用于表示在主动检测连接状态时发现的异常情况。
+ * 这是应用层异常，用户可以捕获并处理。
+ * 
+ * 使用场景：
+ * - 批量操作中主动检测连接状态
+ * - 连接池健康检查
+ * - 协议层状态机中的连接验证
+ * - 半关闭连接检测
+ */
+class ConnectionStateException extends ConnectionException
+{
+    // 连接状态常量
+    public const PEER_CLOSED = 'peer_closed';           // 对端正常关闭
+    public const HALF_CLOSED = 'half_closed';           // TCP 半关闭状态
+    public const CONNECTION_LOST = 'connection_lost';   // 连接异常丢失
+    public const WRITE_CLOSED = 'write_closed';         // 写端关闭
+    public const READ_CLOSED = 'read_closed';           // 读端关闭
+
+    public function __construct(
+        string          $message = "",
+        public readonly string $reason = self::CONNECTION_LOST,
+        Throwable       $previous = null,
+        StreamInterface $stream = null,
+    ) {
+        parent::__construct(
+            $message,
+            ConnectionException::CONNECTION_CLOSED,
+            $previous,
+            $stream,
+        );
+    }
+
+    /**
+     * 判断是否为优雅关闭
+     */
+    public function isGracefulClose(): bool
+    {
+        return in_array($this->reason, [
+            self::PEER_CLOSED,
+            self::HALF_CLOSED,
+            self::WRITE_CLOSED,
+            self::READ_CLOSED
+        ]);
+    }
+
+    /**
+     * 判断是否需要重连
+     */
+    public function shouldReconnect(): bool
+    {
+        return $this->reason === self::CONNECTION_LOST;
+    }
+}

--- a/src/Stream/Exception/README.md
+++ b/src/Stream/Exception/README.md
@@ -1,0 +1,90 @@
+# Stream 异常处理指南
+
+## 异常层次结构
+
+```
+Exception (基础异常)
+├── StreamInternalException (框架内部异常) ⚠️ 禁止应用层捕获
+└── ConnectionException (应用层连接异常基类)
+    ├── ConnectionTimeoutException (连接超时)
+    ├── ConnectionCloseException (连接关闭)
+    └── ConnectionHandshakeException (握手失败)
+```
+
+## 异常职能划分
+
+### StreamInternalException (框架层)
+**用途**: 框架内部控制流，用于底层 I/O 失败时的异常穿透
+
+**抛出场景**:
+- `fread()` 返回 `false`
+- `fwrite()` 返回 `false`  
+- `socket_recv()` 返回 `false`
+- Socket 连接建立失败
+
+**处理方式**: 
+- ❌ **禁止应用层捕获**
+- ✅ 应该穿透到框架的兜底处理区域
+- ✅ 自动关闭连接并清理资源
+
+### ConnectionException (应用层)
+**用途**: 应用层可以捕获和处理的连接相关异常
+
+**子类异常**:
+- `ConnectionTimeoutException`: 连接超时，用户可重试
+- `ConnectionCloseException`: 连接被关闭，用户可重连
+- `ConnectionHandshakeException`: 握手失败，用户可降级或重试
+
+**处理方式**:
+- ✅ 应用层可以捕获
+- ✅ 用户可以实施重试、降级等策略
+- ✅ 用于业务逻辑处理
+
+## 使用示例
+
+### ❌ 错误用法
+```php
+try {
+    $stream->onReadable(function() use ($stream) {
+        $data = $stream->read(1024); // 可能抛出 StreamInternalException
+    });
+} catch (StreamInternalException $e) {
+    // 错误！不应该捕获内部异常
+    // 这会阻止异常穿透到框架处理区域
+}
+```
+
+### ✅ 正确用法
+```php
+try {
+    $socket = Socket::connect('tcp://example.com:443');
+    $socket->enableSSL(); // 可能抛出 ConnectionHandshakeException
+} catch (ConnectionHandshakeException $e) {
+    // 正确！可以捕获并处理握手失败
+    error_log("SSL handshake failed: " . $e->getMessage());
+    // 可以尝试降级到 HTTP 或重试
+}
+
+try {
+    $socket = Socket::connect('tcp://example.com:80', 5.0);
+} catch (ConnectionTimeoutException $e) {
+    // 正确！可以捕获并处理超时
+    error_log("Connection timeout: " . $e->getMessage());
+    // 可以重试或使用备用服务器
+}
+```
+
+## 设计原则
+
+1. **框架异常穿透**: `StreamInternalException` 必须穿透到框架处理区域
+2. **应用异常可控**: `ConnectionException` 及子类供应用层处理
+3. **职责分离**: 不同层次的异常承担不同职责
+4. **类型安全**: 通过类型系统防止误用
+
+## 迁移指南
+
+如果您的代码中捕获了原来的 `ConnectionException`，请检查：
+
+1. 如果捕获的是底层 I/O 异常，请移除 catch 块
+2. 如果捕获的是业务异常，请使用具体的子类异常
+3. 如果需要捕获所有应用层连接异常，继续使用 `ConnectionException`

--- a/src/Stream/Exception/StreamInternalException.php
+++ b/src/Stream/Exception/StreamInternalException.php
@@ -16,25 +16,19 @@ use Psr\Http\Message\StreamInterface;
 use Throwable;
 
 /**
- * 应用层连接异常基类
+ * 框架内部异常 - 用于内部控制流
  * 
- * 此异常及其子类用于表示应用层可以捕获和处理的连接相关错误。
- * 如超时、连接被拒绝、握手失败等用户代码可以合理处理的情况。
- * 
- * 注意：底层 I/O 失败（如 read/write 失败）使用 StreamInternalException，
- * 不应被应用层捕获，而应穿透到框架的兜底处理区域。
+ * 警告：此异常用于框架内部控制流，应用代码不应捕获此异常！
+ * 当底层 I/O 操作失败时，此异常会穿透作用域到框架的兜底区域进行连接清理。
  * 
  * @Author cclilshy
  * @Date   2024/8/16 09:37
  */
-class ConnectionException extends Exception
+final class StreamInternalException extends Exception
 {
-    public const           CONNECTION_CLOSED         = 2;
-    public const           CONNECTION_TIMEOUT        = 4;
-    public const           CONNECTION_HANDSHAKE_FAIL = 32;
-    public const           CONNECTION_ACCEPT_FAIL    = 64;
-    public const           ERROR_ILLEGAL_CONTENT     = 128;
-    public const           CONNECTION_CRYPTO         = 256;
+    public const CONNECTION_ERROR      = 1;
+    public const CONNECTION_READ_FAIL  = 16;
+    public const CONNECTION_WRITE_FAIL = 8;
 
     public function __construct(
         public $message = "",

--- a/src/Stream/Stream.php
+++ b/src/Stream/Stream.php
@@ -13,6 +13,7 @@
 namespace Ripple\Stream;
 
 use Ripple\Stream\Exception\ConnectionException;
+use Ripple\Stream\Exception\StreamInternalException;
 
 use function fclose;
 use function feof;
@@ -54,14 +55,14 @@ class Stream implements StreamInterface
      * @param int $length
      *
      * @return string
-     * @throws ConnectionException
+     * @throws StreamInternalException
      */
     public function read(int $length): string
     {
         $content = @fread($this->stream, $length);
         if ($content === false) {
             $this->close();
-            throw new ConnectionException('Unable to read from stream', ConnectionException::CONNECTION_READ_FAIL);
+            throw new StreamInternalException('Unable to read from stream', StreamInternalException::CONNECTION_READ_FAIL);
         }
         return $content;
     }
@@ -81,14 +82,14 @@ class Stream implements StreamInterface
      * @param string $string
      *
      * @return int
-     * @throws ConnectionException
+     * @throws StreamInternalException
      */
     public function write(string $string): int
     {
         $result = @fwrite($this->stream, $string);
         if ($result === false) {
             $this->close();
-            throw new ConnectionException('Unable to write to stream', ConnectionException::CONNECTION_WRITE_FAIL);
+            throw new StreamInternalException('Unable to write to stream', StreamInternalException::CONNECTION_WRITE_FAIL);
         }
         return $result;
     }


### PR DESCRIPTION
Refactor `ConnectionException` to separate framework-internal control flow exceptions from application-level connection errors.

The original `ConnectionException` had a dual role, intended for internal control flow to tear down connections on I/O failure (preventing event loop deadlocks) but also used for application-level errors. This led to confusion and potential misuse where catching it could prevent critical connection cleanup. This PR introduces `StreamInternalException` for framework-level control flow (not to be caught by application code) and redefines `ConnectionException` and its new subclass `ConnectionHandshakeException` for application-level, catchable errors. This ensures internal exceptions correctly trigger connection destruction while allowing users to handle specific connection-related business logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-30b8bab1-1bfe-44e7-a8d1-8358fff09d75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30b8bab1-1bfe-44e7-a8d1-8358fff09d75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

